### PR TITLE
fix(issue#22): SetSyncPool(true) option panic #22

### DIFF
--- a/task_pool.go
+++ b/task_pool.go
@@ -25,10 +25,11 @@ func newTaskPool() *taskPool {
 }
 
 func (pool *taskPool) get() *Task {
-	return pool.bp.Get().(*Task)
+	task := pool.bp.Get().(*Task)
+	task.Reset()
+	return task
 }
 
 func (pool *taskPool) put(obj *Task) {
-	obj.Reset()
 	pool.bp.Put(obj)
 }


### PR DESCRIPTION
用例执行情况

```shell
➜  go-timewheel (master) ✗ go test -v -bench . -test.bench='TimeWheel$' -test.run ^$
goos: darwin
goarch: amd64
pkg: github.com/rfyiamcool/go-timewheel
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkTimeWheel
BenchmarkTimeWheel/wheel-N-1m
BenchmarkTimeWheel/wheel-N-1m-12                 1000000              1077 ns/op
BenchmarkTimeWheel/wheel-N-5m
BenchmarkTimeWheel/wheel-N-5m-12                 1000000              1777 ns/op
BenchmarkTimeWheel/wheel-N-10m
BenchmarkTimeWheel/wheel-N-10m-12                 936933              1595 ns/op
PASS
ok      github.com/rfyiamcool/go-timewheel      111.565s
```