### PR TITLE
Fix: when delay is less than tick, Ticker runs only once.

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -237,7 +237,7 @@ func (tw *TimeWheel) AddCron(delay time.Duration, callback func()) *Task {
 }
 
 func (tw *TimeWheel) addAny(delay time.Duration, callback func(), circle, async bool) *Task {
-	if delay <= 0 {
+	if delay < tw.tick {
 		delay = tw.tick
 	}
 

--- a/timer_test.go
+++ b/timer_test.go
@@ -209,6 +209,32 @@ func TestTickerSecond(t *testing.T) {
 	assert.Greater(t, incr, 100)
 }
 
+func TestTickerSecondLess(t *testing.T) {
+	tw, err := NewTimeWheel(10*time.Millisecond, 10000)
+	assert.Nil(t, err)
+
+	tw.Start()
+	defer tw.Stop()
+
+	var (
+		timeout = time.After(1100 * time.Millisecond)
+		ticker  = tw.NewTicker(9 * time.Millisecond)
+		incr    int
+	)
+
+	for run := true; run; {
+		select {
+		case <-timeout:
+			run = false
+
+		case <-ticker.C:
+			incr++
+		}
+	}
+
+	assert.Greater(t, incr, 100)
+}
+
 func TestBatchTicker(t *testing.T) {
 	tw, err := NewTimeWheel(100*time.Millisecond, 60)
 	assert.Nil(t, err)


### PR DESCRIPTION
Fixes: #25 

If you find it useful, you can refer to it or merge it.
Of course, you can simply refuse.

```
go test -v -run=TestTickerSecond
=== RUN   TestTickerSecond
--- PASS: TestTickerSecond (0.11s)
=== RUN   TestTickerSecondLess
--- PASS: TestTickerSecondLess (1.10s)
PASS
ok      github.com/rfyiamcool/go-timewheel      1.218s
```