### PR TITLE
Add: ticker.Reset()

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ timer.Stop()
 similar to time.NewTicker
 
 ```
-timer :=tw.NewTicker(5 * time.Second)
-<- timer.C
-timer.Stop()
+ticker := tw.NewTicker(5 * time.Second)
+<- ticker.C
+ticker.Reset(1 * time.Second)
+ticker.Stop()
 ```
 
 similar to time.AfterFunc

--- a/timer.go
+++ b/timer.go
@@ -465,6 +465,21 @@ type Ticker struct {
 	Ctx context.Context
 }
 
+func (t *Ticker) Reset(delay time.Duration) {
+	// first stop old task
+	t.task.stop = true
+
+	// make new task
+	t.task = t.tw.addAny(
+		delay,
+		func() {
+			notfiyChannel(t.C)
+		},
+		modeIsCircle,
+		modeNotAsync,
+	)
+}
+
 func (t *Ticker) Stop() {
 	t.task.stop = true
 	t.cancel()

--- a/timer_test.go
+++ b/timer_test.go
@@ -337,6 +337,45 @@ func TestTimerReset(t *testing.T) {
 	}
 }
 
+func TestTickerReset(t *testing.T) {
+	tw, _ := NewTimeWheel(100*time.Millisecond, 50)
+	tw.Start()
+	defer tw.Stop()
+
+	ticker := tw.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for index := 1; index < 6; index++ {
+		now := time.Now()
+		<-ticker.C
+
+		checkTimeCost(t, now, time.Now(), 80, 220)
+		fmt.Println(time.Since(now).String())
+	}
+
+	fmt.Println()
+	ticker.Reset(300 * time.Millisecond)
+
+	for index := 1; index < 6; index++ {
+		now := time.Now()
+		<-ticker.C
+
+		checkTimeCost(t, now, time.Now(), 280, 420)
+		fmt.Println(time.Since(now).String())
+	}
+
+	fmt.Println()
+	ticker.Reset(200 * time.Millisecond)
+
+	for index := 1; index < 6; index++ {
+		now := time.Now()
+		<-ticker.C
+
+		checkTimeCost(t, now, time.Now(), 180, 320)
+		fmt.Println(time.Since(now).String())
+	}
+}
+
 func TestRemove(t *testing.T) {
 	tw, _ := NewTimeWheel(100*time.Millisecond, 5)
 	tw.Start()


### PR DESCRIPTION
In actual use, some necessary methods have been added.
If you find it useful, you can refer to it or merge it.
Of course, you can simply refuse.

```go
go test -v -run=TestTickerReset
=== RUN   TestTickerReset
199.858669ms
100.193196ms
100.201976ms
99.215373ms
100.173069ms

399.690539ms
300.573191ms
299.446801ms
300.581413ms
299.483389ms

300.611659ms
199.358202ms
200.418955ms
199.422706ms
200.439013ms
--- PASS: TestTickerReset (3.30s)
PASS
ok      github.com/rfyiamcool/go-timewheel      3.304s
```