### PR TITLE
fix tickSafeMode bug, change some apis to allow users to customize

### DIFF
--- a/example/boom/boom.go
+++ b/example/boom/boom.go
@@ -223,7 +223,7 @@ func processCallback(taskCount, delay, beforeDiff, afterDiff int) {
 			incrCounter()
 			// log.info("cost: %s, delay: %d", end.Sub(now), delay)
 		}
-		tw.Add(time.Duration(delay)*time.Second, cb)
+		tw.Add(time.Duration(delay)*time.Second, cb, true)
 	}
 }
 

--- a/example/simple/simple.go
+++ b/example/simple/simple.go
@@ -24,7 +24,7 @@ func main() {
 		for index := 0; index < count; index++ {
 			tw.Add(time.Duration(1*time.Second), func() {
 				queue <- true
-			})
+			}, true)
 		}
 		fmt.Println("add timer cost: ", time.Since(start))
 

--- a/timer_test.go
+++ b/timer_test.go
@@ -43,7 +43,7 @@ func TestCalcPos(t *testing.T) {
 }
 
 func TestAddFunc(t *testing.T) {
-	tw, _ := NewTimeWheel(100*time.Millisecond, 5, TickSafeMode())
+	tw, _ := NewTimeWheel(100*time.Millisecond, 5, TickSafeMode(100*time.Millisecond*10))
 	tw.Start()
 	defer tw.Stop()
 
@@ -52,7 +52,7 @@ func TestAddFunc(t *testing.T) {
 		start := time.Now()
 		tw.Add(time.Duration(index)*time.Second, func() {
 			queue <- true
-		})
+		}, modeIsAsync)
 
 		<-queue
 
@@ -71,7 +71,7 @@ func TestAddStopCron(t *testing.T) {
 	queue := make(chan time.Time, 2)
 	task := tw.AddCron(time.Second*1, func() {
 		queue <- time.Now()
-	})
+	}, modeIsAsync)
 
 	time.AfterFunc(5*time.Second, func() {
 		tw.Remove(task)
@@ -345,7 +345,7 @@ func TestRemove(t *testing.T) {
 	queue := make(chan bool, 0)
 	task := tw.Add(time.Millisecond*500, func() {
 		queue <- true
-	})
+	}, modeIsAsync)
 
 	// remove action after add action
 	time.AfterFunc(time.Millisecond*10, func() {
@@ -398,7 +398,7 @@ func BenchmarkAdd(b *testing.B) {
 	defer tw.Stop()
 
 	for i := 0; i < b.N; i++ {
-		tw.Add(time.Second, func() {})
+		tw.Add(time.Second, func() {}, modeIsAsync)
 	}
 }
 
@@ -485,7 +485,7 @@ func TestResetStop2WithMill(t *testing.T) {
 }
 
 func TestAddRemove(t *testing.T) {
-	tw, err := NewTimeWheel(100*time.Millisecond, 10000, TickSafeMode())
+	tw, err := NewTimeWheel(100*time.Millisecond, 10000, TickSafeMode(100*time.Millisecond*10))
 	assert.Equal(t, nil, err)
 
 	tw.Start()
@@ -495,7 +495,7 @@ func TestAddRemove(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		task := tw.Add(1*time.Second, func() {
 			atomic.AddInt64(&incr, 1)
-		})
+		}, modeIsAsync)
 
 		tw.Remove(task)
 	}
@@ -506,7 +506,7 @@ func TestAddRemove(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		tw.Add(1*time.Second, func() {
 			atomic.AddInt64(&incr, 1)
-		})
+		}, modeIsAsync)
 	}
 
 	time.Sleep(2 * time.Second)

--- a/timewheel.go
+++ b/timewheel.go
@@ -1,6 +1,7 @@
 package timewheel
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -17,16 +18,20 @@ func ResetDefaultTimeWheel(tw *TimeWheel) {
 	DefaultTimeWheel = tw
 }
 
-func Add(delay time.Duration, callback func()) *Task {
-	return DefaultTimeWheel.Add(delay, callback)
+func Add(delay time.Duration, callback func(), async bool) *Task {
+	return DefaultTimeWheel.Add(delay, callback, async)
 }
 
-func AddCron(delay time.Duration, callback func()) *Task {
-	return DefaultTimeWheel.AddCron(delay, callback)
+func AddCron(delay time.Duration, callback func(), async bool) *Task {
+	return DefaultTimeWheel.AddCron(delay, callback, async)
 }
 
 func Remove(task *Task) error {
-	return DefaultTimeWheel.Remove(task)
+	if ok := DefaultTimeWheel.Remove(task); !ok {
+		return fmt.Errorf("fail to remove task:%v", task)
+	}
+	
+	return nil
 }
 
 func NewTimer(delay time.Duration) *Timer {


### PR DESCRIPTION
Recently, I've been working on a project that utilizes your time-wheel timer, and I must say it works exceptionally well and efficiently. In particular, I'm very impressed with the TickSafeMode feature - it's a brilliant idea. However, during the course of using it, I've come across a few minor bugs related to TickSafeMode, and sometimes I need the remove function to return a meaningful value when dealing with potentially timeout-prone asynchronous transactions. Additionally, I believe it would be beneficial to allow users to customize the buffer size for TickSafeMode.

I have made some modifications to address these issues and updated the tests accordingly. I would greatly appreciate it if you could take a look at my changes and provide any feedback or suggestions.